### PR TITLE
Redo user page by removing ranking stats and family stats as we don't use those.

### DIFF
--- a/app/assets/stylesheets/application/user.css
+++ b/app/assets/stylesheets/application/user.css
@@ -93,8 +93,6 @@
 }
 
 .stats .rank {
-    display: inline-block;
-    width: 50%;
     min-width: 130px;
     height: 52px;
 }
@@ -106,6 +104,7 @@
 
 .stats .rank .number {
     font-size: 36px;
+    text-align: center;
 }
 
 .stats .unqualified {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -160,10 +160,6 @@ class UsersController < ApplicationController
             "eternity" => "all time"
         }
         @families = {
-            "pgm-public" => "Objectives/Deathmatch",
-            "mini" => "Mini",
-            "blitz-public" => "Blitz",
-            "micro" => "Micro",
             "global" => "all games"
         }
         @sorts = {

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -26,7 +26,10 @@ module StatsHelper
         end
     end
 
-    def big_stat(num)
+    def mega_stat(num)
         num >= 100_000
+    end    
+    def big_stat(num)
+        num >= 1_000
     end
 end

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -76,15 +76,15 @@
                     .hidden-sm.hidden-xs
                         = join_safe(@kills[0...16].map{|kill| avatar_for(kill.victim_obj, 32, hover: true, link: true)})
                     .name kills
-                    .number{:rel => (big_stat(kills) ? 'tooltip' : ''), :title => "#{kills} kills", :data => {:placement => 'top'}}
-                        = big_stat(kills) ? number_to_human(kills, :format => '%n%u', :units => { :thousand => 'k' }, :precision => 4) : kills
+                    .number{:rel => (mega_stat(kills) ? 'tooltip' : ''), :title => "#{kills} kills", :data => {:placement => 'top'}}
+                        = mega_stat(kills) ? number_to_human(kills, :format => '%n%u', :units => { :thousand => 'k' }, :precision => 4) : kills
                 .col-md-4
                     - deaths = @stats.pretty_stat(:deaths)
                     .hidden-sm.hidden-xs
                         = join_safe(@deaths[0...16].map{|death| avatar_for(death.killer_obj, 32, hover: true, link: true)})
                     .name deaths
-                    .number{:rel => (big_stat(deaths) ? 'tooltip' : ''), :title => "#{deaths} deaths", :data => {:placement => 'top'}}
-                        = big_stat(deaths) ? number_to_human(deaths, :format => '%n%u', :units => { :thousand => 'k' }, :precision => 4) : deaths
+                    .number{:rel => (mega_stat(deaths) ? 'tooltip' : ''), :title => "#{deaths} deaths", :data => {:placement => 'top'}}
+                        = mega_stat(deaths) ? number_to_human(deaths, :format => '%n%u', :units => { :thousand => 'k' }, :precision => 4) : deaths
                 .col-md-4
                     .hidden-sm.hidden-xs
                         = join_safe(@friends.map{|friend| avatar_for(friend, 32, hover: true, link: true, glow: true) })
@@ -97,18 +97,27 @@
         .col-md-4.col-sm-6.col-xs-12
             .stats
                 .well
-                    %h2
-                        = @stats.pretty_stat(:kd)
-                        %small kd
-                    %h2
-                        = @stats.pretty_stat(:kk)
-                        %small kk
-                    %h2
-                        = @player.raindrops
-                        %small Droplets
+                    .rank>
+                        .number 
+                            = PlayerStat.for_period('eternity').for_user(@player).rank('kills')
+                            %sup>= PlayerStat.for_period('eternity').for_user(@player).rank('kills').ordinalize[-2..-1]
+                    .unqualified
+                        %a{href: url_for(controller: 'users', action: 'stats')}
+                            overall in kills
                     .rule
-                    %a{href: "#more_stats", data: {toggle: "modal"}}
-                        %h4.text-primary More Stats
+                    %div
+                        .total>
+                            .number= @stats.pretty_stat(:kd).round(1)
+                            .name kd
+                        .total>
+                            .number= @stats.pretty_stat(:kk).round(1)
+                            .name kk
+                        .total>
+                            .number= big_stat(@player.raindrops) ? number_to_human(@player.raindrops, :format => '%n%u', :units => { :thousand => 'k', :million => 'm' }, :precision => 3) : @player.raindrops
+                            .name droplets
+                        .total>
+                            .number= @objectives.size
+                            .name objectives
 %section
     .row
         .col-md-12
@@ -429,30 +438,3 @@
                                                                 - if current_user_safe.has_permission?('misc','ipban','edit', true)
                                                                     %a{:href => new_admin_ipban_path(:ip => alt.mc_last_sign_in_ip, :description => @player.username), :class => "pull-right btn btn-xs btn-danger"}
                                                                         %i.fa.fa-ban
-.modal.fade#more_stats
-    .modal-dialog
-        .modal-content
-            .modal-header
-                %button.close{:data => {:dismiss => "modal"}} &times;
-                %h3.modal-title
-                    More Stats
-            .modal-body
-                %h3
-                    = "First joined on " + vague_format_time(@intial_join)
-                %h2
-                    = @days_here
-                    %small days since first seen
-                %h2
-                    = @hours_played
-                    %small hours played
-                %h2
-                    = @teams_joined
-                    %small teams joined
-                %h2
-                    = @forum_posts
-                    %small forum posts
-                %h2
-                    = @topics_created
-                    %small topics created
-                .modal-footer
-                    %a.btn.btn-default{:href => "#", :data => {:dismiss => "modal"}} Close

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -119,8 +119,6 @@
                     %li
                         %a{:href => '#trophycase', :data => {:toggle => 'tab'}} Trophy Case
                     %li
-                        %a{:href => '#stats', :data => {:toggle => 'tab'}} Stats
-                    %li
                         %a{:href => '#pvp-encounters', :data => {:toggle => 'tab'}} PvP
                     %li
                         %a{:href => '#objectives', :data => {:toggle => 'tab'}} Objectives
@@ -244,66 +242,6 @@
                                 - else
                                     %pre
                                         Nothing here yet.
-                    .tab-pane#stats
-                        .row
-                            .col-md-3.col-sm-6
-                                %h3{:rel => "tooltip", :title => "First joined on " + vague_format_time(@initial_join), :data => {:placement => "top"}}
-                                    = @days_here
-                                    %small days since first seen
-                            .col-md-3.col-sm-6
-                                %h3
-                                    = @hours_played
-                                    %small hours played
-                            .col-md-3.col-sm-6
-                                %h3
-                                    = @teams_joined
-                                    %small teams joined
-                            .col-md-3.col-sm-6
-                                %h3
-                                    = @player.raindrops
-                                    %small raindrops
-                        %hr
-                        %h4 Forum Stats
-                        .row
-                            .col-md-3.col-sm-6
-                                %h3
-                                    = @forum_posts
-                                    %small forum posts
-                            .col-md-3.col-sm-6
-                                %h3
-                                    = @topics_created
-                                    %small topics started
-                        - @families.each do |name, id|
-                            %hr
-                            %h4
-                                #{name} Stats
-                            .row
-                                .col-md-4
-                                    .row
-                                        .col-sm-6
-                                            %h3
-                                                = @stats.pretty_stat(:kills, id)
-                                                %small kills
-                                        .col-sm-6
-                                            %h3
-                                                = @stats.pretty_stat(:deaths, id)
-                                                %small deaths
-                                .col-md-3
-                                    .row
-                                        .col-sm-6
-                                            %h3
-                                                = @stats.pretty_stat(:kd, id)
-                                                %small kd
-                                        .col-sm-6
-                                            %h3
-                                                = @stats.pretty_stat(:kk, id)
-                                                %small kk
-                                .col-md-5
-                                    .row
-                                        .col-md-6
-                                            %h3
-                                                = (@stats.stat(:playing_time, id).to_f / 1000 / 60 / 60 / 24).round(2)
-                                                %small days played
                     .tab-pane#pvp-encounters
                         .row
                             - if !@encounters.empty?

--- a/app/views/users/show.haml
+++ b/app/views/users/show.haml
@@ -97,36 +97,18 @@
         .col-md-4.col-sm-6.col-xs-12
             .stats
                 .well
-                    - if @ordinal
-                        .rank>
-                            .name rank
-                            %a.number{href: url_for(controller: 'users', action: 'leaderboard', page: @ordinal_page)}
-                                = @ordinal
-                                %sup>= @ordinal.ordinalize[-2..-1]
-                        .rank>
-                            .name rating
-                            .number{rel: 'tooltip',
-                                    title: "1 + (wins - losses) / max(matches, #{Ranking::CONFIDENT_MATCHES})",
-                                    data: {placement: 'bottom'}}
-                                = @ranking.formatted_rating
-                    - else
-                        .unqualified
-                            %a{href: url_for(controller: 'users', action: 'leaderboard')}
-                                not enough recent matches for ranking
+                    %h2
+                        = @stats.pretty_stat(:kd)
+                        %small kd
+                    %h2
+                        = @stats.pretty_stat(:kk)
+                        %small kk
+                    %h2
+                        = @player.raindrops
+                        %small Droplets
                     .rule
-                    %div
-                        .total>
-                            .name matches
-                            .number= @ranking.value.match_count
-                        .total>
-                            .name wins
-                            .number= @ranking.value.wins
-                        .total>
-                            .name losses
-                            .number= @ranking.value.losses
-                        .total>
-                            .name forfeits
-                            .number= @ranking.value.forfeits
+                    %a{href: "#more_stats", data: {toggle: "modal"}}
+                        %h4.text-primary More Stats
 %section
     .row
         .col-md-12
@@ -509,3 +491,30 @@
                                                                 - if current_user_safe.has_permission?('misc','ipban','edit', true)
                                                                     %a{:href => new_admin_ipban_path(:ip => alt.mc_last_sign_in_ip, :description => @player.username), :class => "pull-right btn btn-xs btn-danger"}
                                                                         %i.fa.fa-ban
+.modal.fade#more_stats
+    .modal-dialog
+        .modal-content
+            .modal-header
+                %button.close{:data => {:dismiss => "modal"}} &times;
+                %h3.modal-title
+                    More Stats
+            .modal-body
+                %h3
+                    = "First joined on " + vague_format_time(@intial_join)
+                %h2
+                    = @days_here
+                    %small days since first seen
+                %h2
+                    = @hours_played
+                    %small hours played
+                %h2
+                    = @teams_joined
+                    %small teams joined
+                %h2
+                    = @forum_posts
+                    %small forum posts
+                %h2
+                    = @topics_created
+                    %small topics created
+                .modal-footer
+                    %a.btn.btn-default{:href => "#", :data => {:dismiss => "modal"}} Close


### PR DESCRIPTION
This should remove everything that has to do with rankings that a normal user can see. Also removes the family exclusive stats as we don't have our servers categorized into families. 

Before:
![](https://image.prntscr.com/image/impP--suRHqfLaSOy1hllQ.png)

After:

![](https://image.prntscr.com/image/HSe9pypnRd_ZuNkIjH3KQg.png)


![](https://image.prntscr.com/image/eGuHeYoNR-KKjc-qkqoasg.png)
