### PR TITLE
Comment out the punishment delete button

### DIFF
--- a/app/views/punishments/edit.haml
+++ b/app/views/punishments/edit.haml
@@ -94,7 +94,8 @@
             %hr
             %p You should only edit punishments that you have had a part in. Double check all information before saving.
             %hr
-            - if @can_delete
-                %a.btn.btn-danger{:href => punishment_path(@punishment), :data => {:confirm => 'Are you sure you want to delete this punishment?', :method => :delete}} Delete
-            - else
-                %p You do not have permission to delete this punishment. If you need it removed, please contact a staff member with the appropriate permissions.
+            -#
+              - if @can_delete
+                  %a.btn.btn-danger{:href => punishment_path(@punishment), :data => {:confirm => 'Are you sure you want to delete this punishment?', :method => :delete}} Delete
+              - else
+                  %p You do not have permission to delete this punishment. If you need it removed, please contact a staff member with the appropriate permissions.


### PR DESCRIPTION
I know this is most likely horrible practise, but I asked the delete button to be removed, and it's still there. I want it removed for absolutely everyone, at least in the production website. I haven't tested anything because that's beyond my knowledge.