### PR TITLE
Don't close popover so you can copy it

### DIFF
--- a/app/views/staff/index.haml
+++ b/app/views/staff/index.haml
@@ -31,5 +31,5 @@
                                     %a.staff-contact{:href => "mailto:#{member.public_email}"}
                                         %i.fa.fa-envelope
                                 - if member.discord
-                                    %a.staff-contact{:style => "cursor: pointer", :tabindex => "0", :"data-toggle" => "popover", :"data-placement" => "bottom", :"data-trigger" => "focus", :"data-content" => member.discord}
+                                    %a.staff-contact{:style => "cursor: pointer", :tabindex => "0", :"data-toggle" => "popover", :"data-placement" => "bottom", :"data-content" => member.discord}
                                         %i.fab.fa-discord


### PR DESCRIPTION
Makes the Discord popover on the Staff page not close when you try to copy the username. 