### PR TITLE
Fixed font on play button being cut off in firefox

### DIFF
--- a/app/assets/stylesheets/application/play.css
+++ b/app/assets/stylesheets/application/play.css
@@ -92,7 +92,6 @@
     box-shadow: none;
     color: white;
     background-color: #0088cc;
-    padding: 20px;
     margin: 0;
 }
 


### PR DESCRIPTION
In Firefox the play button currently looks like this: 
![screenshot from 2018-02-23 09-58-11](https://user-images.githubusercontent.com/9515067/36586000-5188c222-1880-11e8-8532-911bb81af9ae.png)

This change fixes that. In Google Chrome this doesn't change anything. Other browsers weren't tested, as I don't have access to them.